### PR TITLE
Enable the use of `__uint128_t` or `uint64_t` if available

### DIFF
--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -8,33 +8,43 @@ on:
 
 jobs:
   build-others:
-    name: ${{ matrix.platform.name }} C++${{matrix.config.cxx_version}}
+    name: ${{ matrix.platform.name }} ${{matrix.wideness.name}} C++${{matrix.config.cxx_version}}
     runs-on: ${{ matrix.platform.os }}
 
     strategy:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2019, os: windows-2019,   flags: -DCMAKE_BUILD_TYPE=Debug }
-        - { name: Windows VS2022, os: windows-2022,   flags: -DCMAKE_BUILD_TYPE=Debug }
-        - { name: Windows Clang,  os: windows-latest, flags: -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
-        - { name: Windows GCC,    os: windows-latest, flags: -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
-        - { name: Linux Clang,    os: ubuntu-latest,  flags: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
-        - { name: Linux GCC,      os: ubuntu-latest,  flags: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
-        - { name: MacOS XCode,    os: macos-latest,   flags: -DCMAKE_BUILD_TYPE=Debug }
-        - { name: MacOS Clang,    os: macos-latest,   flags: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: Windows VS2019,   os: windows-2019,   flags: -DCMAKE_BUILD_TYPE=Debug }
+        - { name: Windows VS2022,   os: windows-2022,   flags: -DCMAKE_BUILD_TYPE=Debug }
+        - { name: Windows Clang,    os: windows-latest, flags: -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: Windows GCC,      os: windows-latest, flags: -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
+        - { name: Linux Clang,      os: ubuntu-latest,  flags: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: Linux GCC,        os: ubuntu-latest,  flags: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
+        - { name: Linux UNIX-POSIX, os: ubuntu-latest,  flags: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=c++ }
+        - { name: MacOS XCode,      os: macos-latest,   flags: -DCMAKE_BUILD_TYPE=Debug }
+        - { name: MacOS Clang,      os: macos-latest,   flags: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         config:
         - { cxx_version: 20 }
-        - { cxx_version: 23 }
+        # - { cxx_version: 23 }
+        wideness:
+        - { name: auto-bit wide limbs }
+        - { name: 32-bit wide limb,  flag: -DFORCE_LIMB_WIDENESS=32 }
+        - { name: 16-bit wide limbs, flag: -DFORCE_LIMB_WIDENESS=16 }
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Update Clang on Windows
+      continue-on-error: true
+      run: choco upgrade llvm
+
     - name: Config
-      run: cmake -S tests -B tests ${{matrix.platform.flags}} -DCMAKE_CXX_STANDARD=${{matrix.config.cxx_version}}
+      run: cmake -S tests -B tests ${{matrix.platform.flags}} -DCMAKE_CXX_STANDARD=${{matrix.config.cxx_version}} ${{matrix.wideness.flag}}
 
     - name: Build
       run: cmake --build tests --config Debug
 
     - name: Tests
-      run: ctest --test-dir tests --build-config Debug --output-on-failure
+      run: ctest --test-dir tests --build-config Debug --verbose
+      # run: ctest --test-dir tests --build-config Debug --output-on-failure

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,8 +5,15 @@ file(GLOB SOURCES "*.cpp")
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(FORCE_LIMB_WIDENESS "" CACHE STRING "Choose an AES Implementation")
 
-# add_compile_definitions(USER_DEFINITION)
+if("${FORCE_LIMB_WIDENESS}" STREQUAL "32")
+    add_compile_definitions(FORCE_32_BIT_LIMBS)
+elseif("${FORCE_LIMB_WIDENESS}" STREQUAL "16")
+    add_compile_definitions(FORCE_16_BIT_LIMBS)
+endif()
+
+message(FORCE_LIMB_WIDENESS="${FORCE_LIMB_WIDENESS}")
 
 if(WIN32)
     # disable windows asan for now since I don't know how to make it work

--- a/tests/comp-info.cpp
+++ b/tests/comp-info.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+#include "../include/epi/epi.hpp"
+
+int main() {
+    std::cout << "epi::LIMB_WIDENESS_COMP_INFO = " << epi::LIMB_WIDENESS_COMP_INFO << "\n";
+    return 0;
+}

--- a/tests/small_test.hpp
+++ b/tests/small_test.hpp
@@ -109,15 +109,15 @@ namespace smlts {
 
     int test::get_final_verdict(std::string const &test_name = "") {
         if (!final_verdict) {
-            std::cout << "\nFINAL VERDICT [" << test_name << "] TEST : PASSED\n";
+            // std::cout << "\nFINAL VERDICT [" << test_name << "] TEST : PASSED\n";
             return 0;
         }
 
-        std::cout << "\nFINAL VERDICT [" << test_name << "] TEST : FAILED\n\n";
-        std::cout << "Failed on test cases :\n";
+        // std::cout << "\nFINAL VERDICT [" << test_name << "] TEST : FAILED\n\n";
+        // std::cout << "Failed on test cases :\n";
 
         for (size_t i = 0; i < file.size(); ++i) {
-            std::cout << "\tfile : " << file[i] << " | line : " << line[i] << "\n";
+            // std::cout << "\tfile : " << file[i] << " | line : " << line[i] << "\n";
         }
 
         return 1;


### PR DESCRIPTION
- new macro directive for detecting if the type `__uint128_t` is available to be use as `cast_t` for 64-bit architectures

- the same macro directive modifications aims to also detect the availability of the type `uint64_t` in 32-bit architectures to be use as `cast_t`

- modified the workflow to force test programs to use `limb_t` of bit wideness 32 and 16

- disable my old test header library's final test output and replace it with cmake's ctest